### PR TITLE
GlobalCompositeOperation cast for TypeScript 4.5.5 and above

### DIFF
--- a/src/Phoria/CanvasRenderer.ts
+++ b/src/Phoria/CanvasRenderer.ts
@@ -39,7 +39,7 @@ export class CanvasRenderer extends Renderer {
             const obj = entity;
             this.ctx.save();
             if (obj.style.compositeOperation) {
-                this.ctx.globalCompositeOperation = obj.style.compositeOperation;
+                this.ctx.globalCompositeOperation = <GlobalCompositeOperation>obj.style.compositeOperation;
             }
             if (obj.style.drawmode === 'solid') {
                 // ensure line width is set if appropriate fillmode is being used


### PR DESCRIPTION
Newer versions of TypeScript may throw an error without this cast